### PR TITLE
save_engine_prefs

### DIFF
--- a/src/main/java/org/asdfjkl/jerryfx/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jerryfx/gui/DialogEngines.java
@@ -189,7 +189,9 @@ public class DialogEngines {
     private void btnRemoveEngineClicked() {
         Engine selectedEngine = engineListView.getSelectionModel().getSelectedItem();
         engineList.remove(selectedEngine);
-        if(engineList.size() > 9) {
+        // Don't know how the size could have got bigger
+        // when we removed an engine, but...
+        if(engineList.size() > GameModel.MAX_N_ENGINES - 1) {
             btnAdd.setDisable(true);
         } else {
             btnAdd.setDisable(false);
@@ -318,7 +320,7 @@ public class DialogEngines {
             }
         }
 
-        if(engineList.size() > 9) {
+        if(engineList.size() > GameModel.MAX_N_ENGINES - 1) {
             btnAdd.setDisable(true);
         } else {
             btnAdd.setDisable(false);

--- a/src/main/java/org/asdfjkl/jerryfx/gui/GameModel.java
+++ b/src/main/java/org/asdfjkl/jerryfx/gui/GameModel.java
@@ -29,6 +29,7 @@ import java.lang.System;
 
 public class GameModel {
 
+    public static final int MAX_N_ENGINES = 10;
     public static final int MODE_ENTER_MOVES = 0;
     public static final int MODE_ANALYSIS = 1;
     public static final int MODE_PLAY_WHITE = 2;
@@ -304,6 +305,11 @@ public class GameModel {
     public void saveEngines() {
 
         prefs = Preferences.userRoot().node(this.getClass().getName());
+        // Clean up preferences. Preferences for engines
+        // which have been removed may still be there.
+        for(int i=1;i<MAX_N_ENGINES;i++) {
+            prefs.remove("ENGINE"+i);
+        }
         for(int i=1;i<engines.size();i++) {
             Engine engine = engines.get(i);
             String engineString = engine.writeToString();
@@ -372,7 +378,7 @@ public class GameModel {
 
         if(mVersion == modelVersion) {
 
-            for(int i=1;i<99;i++) {
+            for(int i=1;i<MAX_N_ENGINES;i++) {
                 String engineString = prefs.get("ENGINE"+i, "");
                 if(!engineString.isEmpty()) {
                     Engine engine = new Engine();


### PR DESCRIPTION
Hello,
My name is Torsten Torell. (TTorell on github) I'm using your Jerry-GUI
to run a chessengine I've been working on now and then. Nice program you
have there. I like the "Full game analysis" and "Play out position" modes
for instance.

I added a few other engines, tried them for a while and then removed them from
the Mode->Engines... dialog. When I closed jerry and restarted it, the "removed"
engines were still in the list. It seems that the preference values for
the engines weren't removed once they had been saved.

To repeat the issue: add a few engines, exit jerry so they will be saved
in the preferences, open jerry again, Remove one or more engines, exit
jerry and restart it. All the engines are still  in the list in DialogEngines.
(At least that was the case for me.)

This pull request seems to fix that problem.

I introduced a MAX_N_ENGINES = 10 constant in GameModel.
(I saw that in GameModel restoreEngines() the loop index went to 99,
but there is a limit of 10 engines in the DialogEngines class before
the add-button is inactivated.) I use the constant directly in
DialogEngines, perhaps it should better be sent in via the constructor
or the show-method. I leave that up to you. Didn't want to change too
much.

I've only tried the fix in Ubuntu 20.04
I found a few more "issues" so maybe there'll be further pull requests,
or at least some issue reports.

I'm kind of new to Github, so i hope i did this the right way.
(Couldn't create the branch directly in your jerry repository, so I forked it first.)

Best regards, Torsten.

