### PR TITLE
Dragging and dropping pgn-files into jfxchess

### DIFF
--- a/src/main/java/org/asdfjkl/jfxchess/gui/App.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/App.java
@@ -70,6 +70,9 @@ public class App extends Application implements StateChangeListener {
 
     String moveBuffer = "";
 
+    private RadioMenuItem itmPlayAsWhite = new RadioMenuItem("Play as White");
+    private RadioMenuItem itmPlayAsBlack = new RadioMenuItem("Play as Black");
+
     @Override
     public void start(Stage stage) {
 
@@ -82,7 +85,6 @@ public class App extends Application implements StateChangeListener {
         //tests.pgnReadAllMillBaseTest();
 
         //FooTest();
-
         gameModel = new GameModel();
         gameModel.restoreModel();
         gameModel.restoreBoardStyle();
@@ -140,9 +142,7 @@ public class App extends Application implements StateChangeListener {
         // Mode Menu
         RadioMenuItem itmAnalysis = new RadioMenuItem("Analysis");
         itmAnalysis.setAccelerator(keyCombinationAnalysis);
-        RadioMenuItem itmPlayAsWhite = new RadioMenuItem("Play as White");
         itmPlayAsWhite.setAccelerator(keyCombinationPlayWhite);
-        RadioMenuItem itmPlayAsBlack = new RadioMenuItem("Play as Black");
         itmPlayAsBlack.setAccelerator(keyCombinationPlayBlack);
         itmEnterMoves = new RadioMenuItem("Enter Moves");
         itmEnterMoves.setAccelerator(keyCombinationEnterMoves);
@@ -998,8 +998,10 @@ public class App extends Application implements StateChangeListener {
             }
             if(dlg.rbComputer.isSelected()) {
                 if(dlg.rbWhite.isSelected()) {
+                    itmPlayAsWhite.setSelected(true);
                     modeMenuController.activatePlayWhiteMode();
                 } else {
+                    itmPlayAsBlack.setSelected(true);
                     modeMenuController.activatePlayBlackMode();
                 }
             } else {

--- a/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/DialogEngines.java
@@ -49,6 +49,7 @@ public class DialogEngines {
 
     final FileChooser fileChooser = new FileChooser();
 
+    Stage ownerStage;
     Stage stage;
     boolean accepted = false;
 
@@ -66,6 +67,10 @@ public class DialogEngines {
     Button btnCancel;
 
     int selectedIndex = 0;
+    
+    public DialogEngines(Stage ownerStage) {
+        this.ownerStage = ownerStage;
+    }
 
     public boolean show(ArrayList<Engine> engines, int idxSelectedEngine, int colorTheme) {
 
@@ -110,6 +115,7 @@ public class DialogEngines {
         });
 
         stage = new Stage();
+        stage.initOwner(ownerStage);
         stage.initModality(Modality.APPLICATION_MODAL);
         stage.setTitle("Chess Engines:");
 

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineInfo.java
@@ -163,7 +163,11 @@ public class EngineInfo {
 
             String line = lines[i];
             
-            multiPv = getInt(MULTIPV, line, 8, multiPv) - 1;
+            Matcher matchPVIdx = MULTIPV.matcher(line);
+            if(matchPVIdx.find()) {
+                String sMultiPV = matchPVIdx.group();
+                multiPv = Integer.parseInt(sMultiPV.substring(8)) - 1;
+            }
             
             nps = getInt(NPS, line, 4, nps);
             hashFull = getInt(HASHFULL, line, 9, hashFull);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/EngineOutputView.java
@@ -94,6 +94,10 @@ public class EngineOutputView implements StateChangeListener {
                 new Text(System.lineSeparator()),
                 pvLines.get(0),
                 new Text(System.lineSeparator()));
+        // The following line fetches the restored number
+        // of pv-lines from gameModel and modifies pvLines
+        // and txtEngineOut by adding lines and children.
+        resetPVLines();
     }
 
     public void enableOutput() { isEnabled = true; }

--- a/src/main/java/org/asdfjkl/jfxchess/gui/GameMenuController.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/GameMenuController.java
@@ -64,20 +64,9 @@ public class GameMenuController {
         }
     }
 
-    public void handleOpenGame() {
-
-        Stage stage = new Stage();
-        stage.initModality(Modality.APPLICATION_MODAL);
-        fileChooser.setTitle("Open PGN File");
-        if(gameModel.lastOpenedDirPath != null && gameModel.lastOpenedDirPath.exists()) {
-            fileChooser.setInitialDirectory(gameModel.lastOpenedDirPath);
-        }
-        fileChooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("PGN", "*.pgn")
-        );
-        File file = fileChooser.showOpenDialog(stage);
+    public void openFile(File file) {
         if (file != null) {
-            if(file.getParentFile() != null) {
+            if (file.getParentFile() != null) {
                 gameModel.lastOpenedDirPath = file.getParentFile();
             }
             // for files >= 20 kb, always open in db window
@@ -96,7 +85,7 @@ public class GameMenuController {
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();
                     } finally {
-                        if(raf!=null) {
+                        if(raf != null) {
                             try {
                                 raf.close();
                             } catch (IOException e) {
@@ -145,6 +134,21 @@ public class GameMenuController {
                 }
             }
         }
+    }
+
+    public void handleOpenGame() {
+
+        Stage stage = new Stage();
+        stage.initModality(Modality.APPLICATION_MODAL);
+        fileChooser.setTitle("Open PGN File");
+        if(gameModel.lastOpenedDirPath != null && gameModel.lastOpenedDirPath.exists()) {
+            fileChooser.setInitialDirectory(gameModel.lastOpenedDirPath);
+        }
+        fileChooser.getExtensionFilters().addAll(
+                new FileChooser.ExtensionFilter("PGN", "*.pgn")
+        );
+        File file = fileChooser.showOpenDialog(stage);
+        openFile(file);
     }
 
     public void handleSaveCurrentGame() {

--- a/src/main/java/org/asdfjkl/jfxchess/gui/ModeMenuController.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/ModeMenuController.java
@@ -29,6 +29,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Locale;
+import javafx.stage.Stage;
 
 public class ModeMenuController implements StateChangeListener {
 
@@ -281,14 +282,14 @@ public class ModeMenuController implements StateChangeListener {
                                              activeEngine.getUciElo());
     }
     
-    public void editEngines() {
+    public void editEngines(Stage ownerStage) {
         // To not be bothered by result notifications during editing engines.
         gameModel.doNotNotifyAboutResult = true;
         // The following call stops the engine-process, set the ENTER_MOVES_MODE
         // and calls GameModel.triggerChangeState(). Previously the engine was
         // not stopped here.
         activateEnterMovesMode();
-        DialogEngines dlg = new DialogEngines();
+        DialogEngines dlg = new DialogEngines(ownerStage);
         ArrayList<Engine> enginesCopy = new ArrayList<>();
         for(Engine engine : gameModel.engines) {
             enginesCopy.add(engine);

--- a/src/main/java/org/asdfjkl/jfxchess/gui/ModeMenuController.java
+++ b/src/main/java/org/asdfjkl/jfxchess/gui/ModeMenuController.java
@@ -149,6 +149,7 @@ public class ModeMenuController implements StateChangeListener {
         if (gameModel.activeEngine.isInternal() || gameModel.eloHasBeenSetInGUI()) {
             engineController.setUciLimitStrength(true);
         }
+        gameModel.setEloHasBeenSetInGUI(false);
         // trigger statechange
         gameModel.setMode(GameModel.MODE_PLAY_BLACK);
         gameModel.setFlipBoard(true);


### PR DESCRIPTION
Hello Dominik!
This time I've experimented with dragging pgn-files from the outside into jfxchess.
It seems to work now, even if I don't like the fix I had to do, explained in the code-comments.
Unfortunately on Linux I get an exception, a known bug, which maybe has been fixed in a later version of javaFX or java.
It does no harm, but I don't know how to  suppress it because it happens when the callback-function goes out of scope.
(So, I have nothing to surround with a try-block, I mean).

There is another problem, which doesn't show up in Windows, only on Linux I guess: If a dialog pops up it's still possible to move the main window around or click on it (twice I think) so it goes to the front and hides the active dialog. (Menus and buttons are not responsive as they shouldn't be). But if this happens by mistake the user may wonder what has happened, and why the application doesn't respond.
I found an antidote to this broblem which I demonstrated on DialogEngines:
We can set the previous stage as owner of the dialog-stage, which will make it always stay on top of the other window.

I leave it to you, to see if the dragging works well on Windows.

I built this branch on top of the other pull-request branch, DialogEngines, which fixes the master-branch after the merge.

